### PR TITLE
chore: use actionsforge dependabot-auto-merge reusable

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,14 +13,5 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
-    steps:
-      - name: Enable auto-merge for Dependabot PRs
-        uses: fastify/github-action-merge-dependabot@1b2ed42db8f9d81a46bac83adedfc03eb5149dff # v3.11.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          target: main
-          merge-method: squash
-          use-github-auto-merge: true
-          skip-verification: false
+    uses: actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Call `actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main`
- Bumps underlying action to v3.15.0; SemVer `target` defaults to `any` (replacing invalid `main`)

## Test plan
- [ ] Hygiene checks pass
- [ ] Next Dependabot PR auto-merge still enables correctly