### PR TITLE
refactor: use docker-image-release reusable workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,69 +8,25 @@ on:
       - "v*"
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
     strategy:
       matrix:
-        image_type: [base, test]
         include:
           - image_type: base
             dockerfile: Dockerfile
             image_suffix: ""
+            create_release: true
           - image_type: test
             dockerfile: Dockerfile.test
             image_suffix: "-test"
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/') && matrix.image_type == 'base'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ""
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            create_release: false
+    uses: actionsforge/actions/.github/workflows/docker-image-release.yml@main
+    with:
+      dockerfile: ${{ matrix.dockerfile }}
+      image-suffix: ${{ matrix.image_suffix }}
+      create-release: ${{ matrix.create_release }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace local build-and-release steps with `actionsforge/actions` `docker-image-release.yml`
- Preserve push triggers (main + v* tags + workflow_dispatch) and GHCR + GitHub Release behavior

## Test plan
- [ ] Workflow calls resolve to actionsforge reusable
- [ ] CI / workflow syntax checks pass